### PR TITLE
Add AutoProxy

### DIFF
--- a/src/WebClient.cls
+++ b/src/WebClient.cls
@@ -33,6 +33,7 @@ Private Const web_DefaultTimeoutMs As Long = 5000
 
 Private pBaseUrl As String
 Private pProxyServer As String
+Private pProxyBypassList As String
 Private pAutoProxyLoaded As Boolean
 
 ' --------------------------------------------- '
@@ -45,30 +46,35 @@ Public Username As String
 Public Password As String
 Public ProxyUsername As String
 Public ProxyPassword As String
-Public ProxyBypassList As String
 Public EnableAutoProxy As Boolean
 
 Public Property Get ProxyServer() As String
     If Me.EnableAutoProxy And Not pAutoProxyLoaded Then
-        On Error GoTo web_ErrorHandling
-        LogDebug "Retrieving AutoProxyServer"
-        WebHelpers.GetAutoProxyServer Me.BaseUrl, pProxyServer
-        LogDebug "AutoProxy: ProxyServer=""" & pProxyServer & """"
-        pAutoProxyLoaded = True
+        LogDebug "Retrieving AutoProxy"
+        web_loadAutoProxy Me.BaseUrl
     End If
 
     ProxyServer = pProxyServer
-    
-    Exit Property
-    
-web_ErrorHandling:
-    LogDebug Err.Source & ": " & Err.Description
-    Resume Next
 End Property
 
 Public Property Let ProxyServer(Value As String)
     ' User defined manually a Proxy -> won't try AutoProxy
     pProxyServer = Value
+    Me.EnableAutoProxy = False
+End Property
+
+Public Property Get ProxyBypassList() As String
+    If Me.EnableAutoProxy And Not pAutoProxyLoaded Then
+        LogDebug "Retrieving AutoProxy"
+        web_loadAutoProxy Me.BaseUrl
+    End If
+
+    ProxyBypassList = pProxyBypassList
+End Property
+
+Public Property Let ProxyBypassList(Value As String)
+    ' User defined manually a Proxy -> won't try AutoProxy
+    pProxyBypassList = Value
     Me.EnableAutoProxy = False
 End Property
 
@@ -277,10 +283,8 @@ Public Function PrepareHttpRequest(Request As WebRequest, Optional Async As Bool
     
     ' AutoProxy for empty BaseUrl
     If EnableAutoProxy And BaseUrl = "" Then
-        LogDebug "Retrieving AutoProxyServer for full URL"
-        WebHelpers.GetAutoProxyServer Me.GetFullUrl(Request), pProxyServer
-        LogDebug "AutoProxy: ProxyServer=""" & pProxyServer & """"
-        pAutoProxyLoaded = True
+        LogDebug "Retrieving AutoProxy for full URL"
+        web_loadAutoProxy Me.GetFullUrl(Request)
     End If
     ' Setup proxy
     If Me.ProxyServer <> "" Then
@@ -320,10 +324,6 @@ Public Function PrepareHttpRequest(Request As WebRequest, Optional Async As Bool
     
 web_ErrorHandling:
 
-    If Err.Source Like "AutoProxy*" Then
-        LogDebug Err.Source & ": " & Err.Description
-        Resume Next
-    End If
     Set web_Http = Nothing
     Err.Raise 11012 + vbObjectError, "WebClient.PrepareHttpRequest", _
         "An error occurred while preparing http request" & vbNewLine & _
@@ -421,6 +421,20 @@ Private Sub web_BeforeExecute(web_Request As WebRequest)
     ' Preparing request includes adding headers
     ' -> Needs to happen after BeforeExecute in case headers were changed
     web_Request.Prepare
+End Sub
+
+Private Sub web_loadAutoProxy(Url As String)
+    On Error GoTo web_ErrorHandling
+    WebHelpers.GetAutoProxy Url, pProxyServer, pProxyBypassList
+    LogDebug "AutoProxy: ProxyServer=""" & pProxyServer & """"
+    LogDebug "AutoProxy: ProxyBypassList=""" & pProxyBypassList & """"
+    pAutoProxyLoaded = True
+    Exit Sub
+    
+web_ErrorHandling:
+
+    LogDebug Err.Source & ": " & Err.Description
+    Resume Next
 End Sub
 
 Private Sub Class_Initialize()

--- a/src/WebHelpers.bas
+++ b/src/WebHelpers.bas
@@ -2280,10 +2280,10 @@ End Function
 '
 '
 ' @param {String} Url
-' @paramreturn {String} ProxyServer
+' @param[out] {String} ProxyServer
+' @param[out] {String} ProxyBypass
 ' --------------------------------------------- '
-
-Public Sub GetAutoProxyServer(Url As String, ByRef ProxyServer As String)
+Public Sub GetAutoProxy(ByVal Url As String, ByRef ProxyServer As String, ByRef ProxyBypass As String)
 #If Mac Then
     ' Windows only !
 #ElseIf VBA7 Then
@@ -2306,6 +2306,7 @@ Public Sub GetAutoProxyServer(Url As String, ByRef ProxyServer As String)
     
     AutoProxy_AutoProxyOptions.AutoProxy_fAutoLogonIfChallenged = 1
     ProxyServer = ""
+    ProxyBypass = ""
     
     ' WinHttpGetProxyForUrl returns unexpected errors if Url is empty
     If Url = "" Then Url = " "
@@ -2394,6 +2395,12 @@ AutoProxy_TryIEFallback:
     If (AutoProxy_ProxyStringPtr <> 0) Then
         AutoProxy_ptr = AutoProxy_SysAllocString(AutoProxy_ProxyStringPtr)
         AutoProxy_CopyMemory VarPtr(ProxyServer), VarPtr(AutoProxy_ptr), 4
+    End If
+    
+    ' Pick up any bypass string from the IEProxyConfig
+    If (AutoProxy_IEProxyConfig.AutoProxy_lpszProxyBypass <> 0) Then
+        AutoProxy_ptr = AutoProxy_SysAllocString(AutoProxy_IEProxyConfig.AutoProxy_lpszProxyBypass)
+        AutoProxy_CopyMemory VarPtr(ProxyBypass), VarPtr(AutoProxy_ptr), 4
     End If
     
     ' Ensure WinHttp session is closed, an error might have occurred


### PR DESCRIPTION
This adds automatic proxy server configuration on Windows.

When EnableAutoProxy is set (default), instances of the WebClient class will receive the appropriate proxy server for their BaseUrl.

Retrieves IE settings, including auto-detect and auto-config scripts and applies according to the specified BaseUrl.

Closes #69
