### PR TITLE
Bugfixes (cURL escaping, url-encode UrlSegments, add SetHeader)

### DIFF
--- a/authenticators/DigestAuthenticator.cls
+++ b/authenticators/DigestAuthenticator.cls
@@ -81,7 +81,7 @@ End Sub
 Private Sub IWebAuthenticator_BeforeExecute(ByVal Client As WebClient, ByRef Request As WebRequest)
     If Me.IsAuthenticated Then
         Me.RequestCount = Me.RequestCount + 1
-        Request.AddHeader "Authorization", CreateHeader(Client, Request)
+        Request.SetHeader "Authorization", CreateHeader(Client, Request)
     End If
 End Sub
 
@@ -97,7 +97,7 @@ Private Sub IWebAuthenticator_AfterExecute(ByVal Client As WebClient, ByVal Requ
         WebHelpers.LogDebug "Extract Authenticate and retry 401 request " & Client.GetFullUrl(Request), "Digest.AfterExecute"
         ExtractAuthenticateInformation Response
         
-        Request.AddHeader "Authorization", CreateHeader(Client, Request)
+        Request.SetHeader "Authorization", CreateHeader(Client, Request)
         Response.Update Client.Execute(Request)
     End If
 End Sub

--- a/authenticators/DigestAuthenticator.cls
+++ b/authenticators/DigestAuthenticator.cls
@@ -122,7 +122,7 @@ End Sub
 ''
 Private Sub IWebAuthenticator_PrepareCurl(ByVal Client As WebClient, ByVal Request As WebRequest, ByRef Curl As String)
     ' http://curl.haxx.se/docs/manpage.html#--digest
-    Curl = Curl & " --digest --user " & Me.Username & ":" & Me.Password
+    Curl = Curl & " --digest --user " & WebHelpers.PrepareTextForShell(Me.Username) & ":" & WebHelpers.PrepareTextForShell(Me.Password)
 End Sub
 
 ''

--- a/authenticators/GoogleAuthenticator.cls
+++ b/authenticators/GoogleAuthenticator.cls
@@ -242,7 +242,7 @@ Private Sub IWebAuthenticator_BeforeExecute(ByVal Client As WebClient, ByRef Req
             Me.Token = Me.GetToken(Client)
         End If
     
-        Request.AddHeader "Authorization", "Bearer " & Me.Token
+        Request.SetHeader "Authorization", "Bearer " & Me.Token
     End If
 End Sub
 

--- a/authenticators/HttpBasicAuthenticator.cls
+++ b/authenticators/HttpBasicAuthenticator.cls
@@ -57,7 +57,7 @@ End Sub
 ' @param in|out {WebRequest} Request The request about to be executed
 ''
 Private Sub IWebAuthenticator_BeforeExecute(ByVal Client As WebClient, ByRef Request As WebRequest)
-    Request.AddHeader "Authorization", "Basic " & WebHelpers.Base64Encode(Me.Username & ":" & Me.Password)
+    Request.SetHeader "Authorization", "Basic " & WebHelpers.Base64Encode(Me.Username & ":" & Me.Password)
 End Sub
 
 ''

--- a/authenticators/HttpBasicAuthenticator.cls
+++ b/authenticators/HttpBasicAuthenticator.cls
@@ -91,6 +91,6 @@ End Sub
 ''
 Private Sub IWebAuthenticator_PrepareCurl(ByVal Client As WebClient, ByVal Request As WebRequest, ByRef Curl As String)
     ' e.g. Add flags to cURL
-    Curl = Curl & " --basic --user " & Me.Username & ":" & Me.Password
+    Curl = Curl & " --basic --user " & WebHelpers.PrepareTextForShell(Me.Username) & ":" & WebHelpers.PrepareTextForShell(Me.Password)
 End Sub
 

--- a/authenticators/OAuth1Authenticator.cls
+++ b/authenticators/OAuth1Authenticator.cls
@@ -70,7 +70,7 @@ End Sub
 ''
 Private Sub IWebAuthenticator_BeforeExecute(ByVal Client As WebClient, ByRef Request As WebRequest)
     ' Add authorization header to request
-    Request.AddHeader "Authorization", CreateHeader(Client, Request)
+    Request.SetHeader "Authorization", CreateHeader(Client, Request)
 End Sub
 
 ''

--- a/authenticators/OAuth2Authenticator.cls
+++ b/authenticators/OAuth2Authenticator.cls
@@ -65,7 +65,7 @@ Private Sub IWebAuthenticator_BeforeExecute(ByVal Client As WebClient, ByRef Req
         Me.Token = Me.GetToken(Client)
     End If
     
-    Request.AddHeader "Authorization", "Bearer " & Me.Token
+    Request.SetHeader "Authorization", "Bearer " & Me.Token
 End Sub
 
 ''

--- a/authenticators/TwitterAuthenticator.cls
+++ b/authenticators/TwitterAuthenticator.cls
@@ -68,7 +68,7 @@ Private Sub IWebAuthenticator_BeforeExecute(ByVal Client As WebClient, ByRef Req
         Me.Token = Me.GetToken(Client)
     End If
 
-    Request.AddHeader "Authorization", "Bearer " & Me.Token
+    Request.SetHeader "Authorization", "Bearer " & Me.Token
 End Sub
 
 ''
@@ -129,7 +129,7 @@ Public Function GetToken(auth_Client As WebClient) As String
     auth_Request.RequestFormat = WebFormat.FormUrlEncoded
     auth_Request.ResponseFormat = WebFormat.Json
     
-    auth_Request.AddHeader "Authorization", _
+    auth_Request.SetHeader "Authorization", _
         "Basic " & WebHelpers.Base64Encode(Me.ConsumerKey & ":" & Me.ConsumerSecret)
     auth_Request.AddBodyParameter "grant_type", "client_credentials"
     

--- a/specs/Specs_HttpBasicAuthenticator.bas
+++ b/specs/Specs_HttpBasicAuthenticator.bas
@@ -25,10 +25,29 @@ Public Function Specs() As SpecSuite
         Request.AddUrlSegment "user", "Tim"
         Request.AddUrlSegment "password", "Secret123"
         
+        Set Client.Authenticator = Nothing
         Set Response = Client.Execute(Request)
         .Expect(Response.StatusCode).ToEqual WebStatusCode.Unauthorized
         
         Auth.Setup "Tim", "Secret123"
+        Set Client.Authenticator = Auth
+        
+        Set Response = Client.Execute(Request)
+        .Expect(Response.StatusCode).ToEqual 200
+        .Expect(Response.Data("authenticated")).ToEqual True
+    End With
+    
+    With Specs.It("should properly escape username and password")
+        Set Request = New WebRequest
+        Request.Resource = "basic-auth/{user}/{password}"
+        Request.AddUrlSegment "user", "Tim\`$""!"
+        Request.AddUrlSegment "password", "Secret123\`$""!"
+        
+        Set Client.Authenticator = Nothing
+        Set Response = Client.Execute(Request)
+        .Expect(Response.StatusCode).ToEqual WebStatusCode.Unauthorized
+        
+        Auth.Setup "Tim\`$""!", "Secret123\`$""!"
         Set Client.Authenticator = Auth
         
         Set Response = Client.Execute(Request)

--- a/specs/Specs_WebHelpers.bas
+++ b/specs/Specs_WebHelpers.bas
@@ -399,8 +399,7 @@ Public Function Specs() As SpecSuite
     ' ============================================= '
     ' 7. Mac
     ' ============================================= '
-
-#If Mac Then
+    
     ' ExecuteInShell
     
     ' PrepareTextForShell
@@ -410,7 +409,6 @@ Public Function Specs() As SpecSuite
         .Expect(WebHelpers.PrepareTextForShell("!abc!123!")).ToEqual "'!'""abc""'!'""123""'!'"
         .Expect(WebHelpers.PrepareTextForShell("`!$\""%")).ToEqual """\`""'!'""\$\\\""\%"""
     End With
-#End If
     
     ' ============================================= '
     ' 8. Cryptography

--- a/specs/Specs_WebRequest.bas
+++ b/specs/Specs_WebRequest.bas
@@ -224,6 +224,15 @@ Public Function Specs() As SpecSuite
         .Expect(Request.FormattedResource).ToEqual "A/B/C/D"
     End With
     
+    With Specs.It("FormattedResource should url-encode Url Segments")
+        Set Request = New WebRequest
+        
+        Request.Resource = "{segment}"
+        Request.AddUrlSegment "segment", "$&+,/:;=?@"
+        
+        .Expect(Request.FormattedResource).ToEqual "%24%26%2B%2C%2F%3A%3B%3D%3F%40"
+    End With
+    
     With Specs.It("FormattedResource should include querystring parameters")
         Set Request = New WebRequest
     
@@ -301,24 +310,6 @@ Public Function Specs() As SpecSuite
         
         .Expect(Request.Body).ToEqual "{""A"":123,""B"":456}"
     End With
-    
-    ' TODO
-    'With Specs.It("AddBodyParameter should throw TODO if adding to existing Body this is not Dictionary")
-    '    On Error Resume Next
-    '    Set Request = New WebRequest
-    '
-    '    Request.Body = Array("A", "B", "C")
-    '    Request.AddBodyParameter "D", 123
-    '
-    '    ' TODO Check actual error number
-    '    .Expect(Err.Number).ToNotEqual 0
-    '    Debug.Print Err.Number & ": " & Err.Description
-    '    .Expect(Err.Description).ToEqual _
-    '        "The existing body is not a Dictionary. Adding body parameters can only be used with Dictionaries"
-    '
-    '    Err.Clear
-    '    On Error GoTo 0
-    'End With
     
     ' AddCookie
     ' --------------------------------------------- '

--- a/specs/Specs_WebRequest.bas
+++ b/specs/Specs_WebRequest.bas
@@ -337,6 +337,21 @@ Public Function Specs() As SpecSuite
         .Expect(Request.Headers(2)("Value")).ToEqual "header 2"
     End With
     
+    ' SetHeader
+    ' --------------------------------------------- '
+    With Specs.It("should SetHeader")
+        Set Request = New WebRequest
+        
+        Request.AddHeader "A", "add"
+        
+        Request.SetHeader "A", "set"
+        Request.SetHeader "B", "header"
+        
+        .Expect(Request.Headers.Count).ToEqual 2
+        .Expect(Request.Headers(1)("Value")).ToEqual "set"
+        .Expect(Request.Headers(2)("Key")).ToEqual "B"
+    End With
+    
     ' AddQuerystringParam
     ' --------------------------------------------- '
     With Specs.It("should AddQuerystringParam")

--- a/src/WebHelpers.bas
+++ b/src/WebHelpers.bas
@@ -1414,7 +1414,6 @@ End Sub
 ' ============================================= '
 ' 7. Mac
 ' ============================================= '
-#If Mac Then
 
 ''
 ' Execute the given command
@@ -1425,6 +1424,7 @@ End Sub
 ' @return {ShellResult}
 ''
 Public Function ExecuteInShell(web_Command As String) As ShellResult
+#If Mac Then
     Dim web_File As Long
     Dim web_Chunk As String
     Dim web_Read As Long
@@ -1450,6 +1450,7 @@ Public Function ExecuteInShell(web_Command As String) As ShellResult
 web_Cleanup:
 
     ExecuteInShell.ExitCode = web_pclose(web_File)
+#End If
 End Function
 
 ''
@@ -1487,8 +1488,6 @@ Public Function PrepareTextForShell(ByVal web_Text As String) As String
     
     PrepareTextForShell = web_Text
 End Function
-
-#End If
 
 ' ============================================= '
 ' 8. Cryptography

--- a/src/WebHelpers.bas
+++ b/src/WebHelpers.bas
@@ -1244,7 +1244,9 @@ Public Sub AddOrReplaceInKeyValues(KeyValues As Collection, Key As Variant, Valu
             ' Replace existing
             KeyValues.Remove web_Index
             
-            If web_Index > KeyValues.Count Then
+            If KeyValues.Count = 0 Then
+                KeyValues.Add web_NewKeyValue
+            ElseIf web_Index > KeyValues.Count Then
                 KeyValues.Add web_NewKeyValue, After:=web_Index - 1
             Else
                 KeyValues.Add web_NewKeyValue, Before:=web_Index

--- a/src/WebRequest.cls
+++ b/src/WebRequest.cls
@@ -507,14 +507,14 @@ End Property
 ' ============================================= '
 
 ''
-' Add header to be sent with request
+' Add header to be sent with request.
 '
 ' @example
 ' ```VB.net
 ' Dim Request As New WebRequest
 ' Request.AddHeader "Authentication", "Bearer ..."
 '
-' ' -> (Header) Authentication: Bearer ...
+' ' -> (Header) Authorization: Bearer ...
 ' ```
 '
 ' @method AddHeader
@@ -523,6 +523,35 @@ End Property
 ''
 Public Sub AddHeader(Key As String, Value As Variant)
     Me.Headers.Add WebHelpers.CreateKeyValue(Key, Value)
+End Sub
+
+''
+' Add/replace header to be sent with request.
+' `SetHeader` should be used for headers that can only be included once with a request
+' (e.g. Authorization, Content-Type, etc.).
+'
+' @example
+' ```VB.net
+' Dim Request As New WebRequest
+' Request.AddHeader "Authorization", "A..."
+' Request.AddHeader "Authorization", "B..."
+'
+' ' -> Headers:
+' '    Authorization: A...
+' '    Authorization: B...
+'
+' Request.SetHeader "Authorization", "C..."
+'
+' ' -> Headers:
+' '    Authorization: C...
+' ```
+'
+' @method SetHeader
+' @param {String} Key
+' @param {Variant} Value
+''
+Public Sub SetHeader(Key As String, Value As Variant)
+    WebHelpers.AddOrReplaceInKeyValues Me.Headers, Key, Value
 End Sub
 
 ''
@@ -651,10 +680,10 @@ End Sub
 ''
 Public Sub Prepare()
     ' Add/replace general headers for request
-    WebHelpers.AddOrReplaceInKeyValues Me.Headers, "User-Agent", WebUserAgent
-    WebHelpers.AddOrReplaceInKeyValues Me.Headers, "Content-Type", Me.ContentType
-    WebHelpers.AddOrReplaceInKeyValues Me.Headers, "Accept", Me.Accept
-    WebHelpers.AddOrReplaceInKeyValues Me.Headers, "Content-Length", VBA.CStr(Me.ContentLength)
+    SetHeader "User-Agent", WebUserAgent
+    SetHeader "Content-Type", Me.ContentType
+    SetHeader "Accept", Me.Accept
+    SetHeader "Content-Length", VBA.CStr(Me.ContentLength)
 End Sub
 
 ''

--- a/src/WebRequest.cls
+++ b/src/WebRequest.cls
@@ -477,7 +477,7 @@ Public Property Get FormattedResource() As String
     
     ' Replace url segments
     For Each web_Segment In Me.UrlSegments.Keys
-        FormattedResource = VBA.Replace(FormattedResource, "{" & web_Segment & "}", Me.UrlSegments(web_Segment))
+        FormattedResource = VBA.Replace(FormattedResource, "{" & web_Segment & "}", WebHelpers.UrlEncode(Me.UrlSegments(web_Segment)))
     Next web_Segment
     
     ' Add querystring


### PR DESCRIPTION
- Escape `Username` and `Password` for cURL shell in authenticators
- Url-Encode UrlSegments
- Add `SetHeader` to `WebRequest` to ensure desired header is only added once to request (required for Authorization, Content-Type, and others)

Fixes #89 #90 #91 
