### PR TITLE
Resolve memory free bug in AutoProxy

### DIFF
--- a/src/WebHelpers.bas
+++ b/src/WebHelpers.bas
@@ -2628,7 +2628,7 @@ End Function
 #End If
 
 ''
-' AutoProxy 1.0.0
+' AutoProxy 1.0.1
 ' (c) Damien Thirion
 '
 ' Auto configure proxy server
@@ -2781,21 +2781,28 @@ AutoProxy_TryIEFallback:
     End If
     
 AutoProxy_Cleanup:
+    On Error GoTo 0
+    
     ' Free any strings received from WinHttp APIs
     If (AutoProxy_IEProxyConfig.AutoProxy_lpszAutoConfigUrl <> 0) Then
-        AutoProxy_GlobalFree (AutoProxy_IEProxyConfig.AutoProxy_lpszAutoConfigUrl)
+        AutoProxy_GlobalFree AutoProxy_IEProxyConfig.AutoProxy_lpszAutoConfigUrl
+        AutoProxy_IEProxyConfig.AutoProxy_lpszAutoConfigUrl = 0
     End If
     If (AutoProxy_IEProxyConfig.AutoProxy_lpszProxy <> 0) Then
-        AutoProxy_GlobalFree (AutoProxy_IEProxyConfig.AutoProxy_lpszProxy)
+        AutoProxy_GlobalFree AutoProxy_IEProxyConfig.AutoProxy_lpszProxy
+        AutoProxy_IEProxyConfig.AutoProxy_lpszProxy = 0
     End If
     If (AutoProxy_IEProxyConfig.AutoProxy_lpszProxyBypass <> 0) Then
-        AutoProxy_GlobalFree (AutoProxy_IEProxyConfig.AutoProxy_lpszProxyBypass)
+        AutoProxy_GlobalFree AutoProxy_IEProxyConfig.AutoProxy_lpszProxyBypass
+        AutoProxy_IEProxyConfig.AutoProxy_lpszProxyBypass = 0
     End If
     If (AutoProxy_ProxyInfo.AutoProxy_lpszProxy <> 0) Then
-        AutoProxy_GlobalFree (AutoProxy_ProxyInfo.AutoProxy_lpszProxy)
+        AutoProxy_GlobalFree AutoProxy_ProxyInfo.AutoProxy_lpszProxy
+        AutoProxy_ProxyInfo.AutoProxy_lpszProxy = 0
     End If
     If (AutoProxy_ProxyInfo.AutoProxy_lpszProxyBypass <> 0) Then
-        AutoProxy_GlobalFree (AutoProxy_ProxyInfo.AutoProxy_lpszProxyBypass)
+        AutoProxy_GlobalFree AutoProxy_ProxyInfo.AutoProxy_lpszProxyBypass
+        AutoProxy_ProxyInfo.AutoProxy_lpszProxyBypass = 0
     End If
     
     ' Error handling


### PR DESCRIPTION
Re-throwing error in AutoProxy caused cleanup to run twice which led to pointers being attempted to be re-freed causing Excel to crash. This fixes re-throwing from running cleanup again and sets freed pointers to 0.

Fixes #108 and #102