### PR TITLE
Follow redirects

### DIFF
--- a/specs/Specs_WebClient.bas
+++ b/specs/Specs_WebClient.bas
@@ -88,6 +88,22 @@ Public Function Specs() As SpecSuite
         Client.Insecure = False
     End With
     
+    ' FollowRedirects
+    ' --------------------------------------------- '
+    With Specs.It(" should FollowRedirects")
+        Set Request = New WebRequest
+        Request.Resource = "redirect/5"
+        Request.Format = WebFormat.PlainText
+        
+        Client.FollowRedirects = True
+        Set Response = Client.Execute(Request)
+        .Expect(Response.StatusCode).ToEqual WebStatusCode.Ok
+        
+        Client.FollowRedirects = False
+        Set Response = Client.Execute(Request)
+        .Expect(Response.StatusCode).ToEqual 302
+    End With
+    
     ' ============================================= '
     ' Public Methods
     ' ============================================= '

--- a/specs/Specs_WebClient.bas
+++ b/specs/Specs_WebClient.bas
@@ -258,18 +258,6 @@ Public Function Specs() As SpecSuite
     
     ' SetProxy
     
-    ' GetRedirectLocation
-    ' --------------------------------------------- '
-    With Specs.It("should GetRedirectLocation of Request")
-        Set Request = New WebRequest
-        Request.Resource = "redirect/1"
-        
-        Dim RedirectLocation As String
-        RedirectLocation = Client.GetRedirectLocation(Request)
-        
-        .Expect(RedirectLocation).ToEqual "/get"
-    End With
-    
     ' GetFullUrl
     ' --------------------------------------------- '
     With Specs.It("should GetFullUrl of Request")

--- a/src/WebClient.cls
+++ b/src/WebClient.cls
@@ -184,6 +184,15 @@ Public EnableAutoProxy As Boolean
 Public Insecure As Boolean
 
 ''
+' Follow redirects (301, 302, 307) using Location header
+'
+' @property FollowRedirects
+' @type Boolean
+' @default True
+''
+Public FollowRedirects As Boolean
+
+''
 ' Proxy server to pass requests through (except for those that match `ProxyBypassList`).
 '
 ' @property ProxyServer
@@ -535,23 +544,22 @@ Public Function PrepareHttpRequest(Request As WebRequest, Optional Async As Bool
         '   Invalid common name (CN), 0x1000
         '   Invalid date or certificate expired, 0x2000
         '   = 0x3300 = 13056
-        ' - Enable redirects
         ' - Enable https-to-http redirects
         web_Http.Option(web_WinHttpRequestOption.web_WinHttpRequestOption_EnableCertificateRevocationCheck) = False
         web_Http.Option(web_WinHttpRequestOption.web_WinHttpRequestOption_SslErrorIgnoreFlags) = 13056
-        web_Http.Option(web_WinHttpRequestOption.web_WinHttpRequestOption_EnableRedirects) = True
         web_Http.Option(web_WinHttpRequestOption.web_WinHttpRequestOption_EnableHttpsToHttpRedirects) = True
     Else
         ' By default:
         ' - Enable certificate revocation check (especially useful after HeartBleed)
         ' - Ignore no SLL erros
-        ' - Disable redirects (matches cURL behavior)
         ' - Disable https-to-http redirects
         web_Http.Option(web_WinHttpRequestOption.web_WinHttpRequestOption_EnableCertificateRevocationCheck) = True
         web_Http.Option(web_WinHttpRequestOption.web_WinHttpRequestOption_SslErrorIgnoreFlags) = 0
-        web_Http.Option(web_WinHttpRequestOption.web_WinHttpRequestOption_EnableRedirects) = False
         web_Http.Option(web_WinHttpRequestOption.web_WinHttpRequestOption_EnableHttpsToHttpRedirects) = False
     End If
+    
+    ' Setup redirects
+    web_Http.Option(web_WinHttpRequestOption.web_WinHttpRequestOption_EnableRedirects) = Me.FollowRedirects
     
     ' Set headers on http request (after open)
     For Each web_KeyValue In Request.Headers
@@ -621,6 +629,11 @@ Public Function PrepareCurlRequest(Request As WebRequest) As String
     ' Setup security
     If Me.Insecure Then
         web_Curl = web_Curl & " --insecure"
+    End If
+    
+    ' Setup redirects
+    If Me.FollowRedirects Then
+        web_Curl = web_Curl & " --location"
     End If
     
     ' Set headers and cookies
@@ -734,4 +747,5 @@ Private Sub Class_Initialize()
     Me.TimeoutMs = web_DefaultTimeoutMs
     Me.EnableAutoProxy = False
     Me.Insecure = False
+    Me.FollowRedirects = True
 End Sub

--- a/src/WebClient.cls
+++ b/src/WebClient.cls
@@ -459,26 +459,6 @@ Public Sub SetProxy(ProxyServer As String, _
 End Sub
 
 ''
-' If the given Request is a redirect (301, 302, or 307),
-' then get value of the "Location" header
-'
-' @param {WebRequest} Request
-' @return {String}
-''
-Public Function GetRedirectLocation(Request As WebRequest) As String
-    Dim RedirectRequest As WebRequest
-    Set RedirectRequest = Request.Clone
-    RedirectRequest.Method = WebMethod.HttpHead
-    
-    Dim Response As WebResponse
-    Set Response = Me.Execute(RedirectRequest)
-    
-    If Response.StatusCode = 301 Or Response.StatusCode = 302 Or Response.StatusCode = 307 Then
-        GetRedirectLocation = WebHelpers.FindInKeyValues(Response.Headers, "Location")
-    End If
-End Function
-
-''
 ' Get full url by joining given `WebRequest.FormattedResource` and `BaseUrl`.
 '
 ' @method GetFullUrl


### PR DESCRIPTION
Add `FollowRedirects` option to `WebClient`, enabled by default. Disabling redirects for WinHttp happened in https://github.com/VBA-tools/VBA-Web/commit/a3e5cd98a6581eebeafceabf35f88d396d77790b (v4.0.12) so this doesn't technically break backwards compatibility:

- v4.0.0: Windows enabled, Mac disabled
- v4.0.12: Windows disabled, Mac disabled
- v4.0.next: Windows enabled, Mac enabled

Fixes #131