### PR TITLE
Use internal version of CrLf

### DIFF
--- a/authenticators/DigestAuthenticator.cls
+++ b/authenticators/DigestAuthenticator.cls
@@ -159,11 +159,14 @@ End Function
 ''
 Public Sub ExtractAuthenticateInformation(Response As WebResponse)
     Dim auth_Header As String
+    Dim web_CrLf As String
+    
     auth_Header = WebHelpers.FindInKeyValues(Response.Headers, "WWW-Authenticate")
+    web_CrLf = VBA.Chr$(13) & VBA.Chr$(10)
     
     If auth_Header <> "" And VBA.Left$(auth_Header, 6) = "Digest" Then
         Dim auth_Lines As Variant
-        auth_Lines = VBA.Split(VBA.Mid$(auth_Header, 7), vbCrLf)
+        auth_Lines = VBA.Split(VBA.Mid$(auth_Header, 7), web_CrLf)
         
         Dim auth_i As Integer
         Dim auth_Key As String

--- a/specs/Specs_DigestAuthenticator.bas
+++ b/specs/Specs_DigestAuthenticator.bas
@@ -13,6 +13,9 @@ Public Function Specs() As SpecSuite
     Set Specs = New SpecSuite
     Specs.Description = "DigestAuthenticator"
     
+    Dim web_CrLf As String
+    web_CrLf = VBA.Chr$(13) & VBA.Chr$(10)
+    
     Dim Auth As New DigestAuthenticator
     Auth.Setup "Mufasa", "Circle Of Life"
     Auth.Realm = "testrealm@host.com"
@@ -54,9 +57,9 @@ Public Function Specs() As SpecSuite
         Dim Unauthorized As New WebResponse
         Unauthorized.StatusCode = 401
         
-        Unauthorized.Headers.Add WebHelpers.CreateKeyValue("WWW-Authenticate", "Digest realm=""testrealm@host.com""," & vbCrLf & _
-                            "qop=""auth,auth-int""," & vbCrLf & _
-                            "nonce=""dcd98b7102dd2f0e8b11d0f600bfb0c093""," & vbCrLf & _
+        Unauthorized.Headers.Add WebHelpers.CreateKeyValue("WWW-Authenticate", "Digest realm=""testrealm@host.com""," & web_CrLf & _
+                            "qop=""auth,auth-int""," & web_CrLf & _
+                            "nonce=""dcd98b7102dd2f0e8b11d0f600bfb0c093""," & web_CrLf & _
                             "Opaque = ""5ccc069c403ebaf9f0171e9517f40e41""")
     
         Auth.Realm = ""

--- a/specs/Specs_WebResponse.bas
+++ b/specs/Specs_WebResponse.bas
@@ -22,6 +22,9 @@ Public Function Specs() As SpecSuite
     Dim Cookies As Collection
     Dim Curl As String
     
+    Dim web_CrLf As String
+    web_CrLf = VBA.Chr$(13) & VBA.Chr$(10)
+    
     Client.BaseUrl = HttpbinBaseUrl
     Client.TimeoutMs = 5000
     
@@ -173,13 +176,13 @@ Public Function Specs() As SpecSuite
         Set Response = New WebResponse
         
         Request.Format = WebFormat.PlainText
-        Curl = "HTTP/1.1 100 Continue" & vbCrLf & _
-            vbCrLf & _
-            "HTTP/1.1 100 Continue" & vbCrLf & _
-            vbCrLf & _
-            "HTTP/1.1 200 OK" & vbCrLf & _
-            "Set-Cookie: message=Howdy!" & vbCrLf & _
-            vbCrLf & _
+        Curl = "HTTP/1.1 100 Continue" & web_CrLf & _
+            web_CrLf & _
+            "HTTP/1.1 100 Continue" & web_CrLf & _
+            web_CrLf & _
+            "HTTP/1.1 200 OK" & web_CrLf & _
+            "Set-Cookie: message=Howdy!" & web_CrLf & _
+            web_CrLf & _
             "Text"
         
         Response.CreateFromCurl Client, Request, Curl
@@ -195,10 +198,10 @@ Public Function Specs() As SpecSuite
     ' --------------------------------------------- '
     With Specs.It("ExtractHeaders should extract headers from response headers")
         Set Response = New WebResponse
-        ResponseHeaders = "Connection: keep -alive" & vbCrLf & _
-            "Date: Tue, 18 Feb 2014 15:00:26 GMT" & vbCrLf & _
-            "Content-Length: 2" & vbCrLf & _
-            "Content-Type: text/plain" & vbCrLf & _
+        ResponseHeaders = "Connection: keep -alive" & web_CrLf & _
+            "Date: Tue, 18 Feb 2014 15:00:26 GMT" & web_CrLf & _
+            "Content-Length: 2" & web_CrLf & _
+            "Content-Type: text/plain" & web_CrLf & _
             "Set-Cookie: cookie=simple-cookie; Path=/"
 
         Set Headers = Response.ExtractHeaders(ResponseHeaders)
@@ -210,20 +213,20 @@ Public Function Specs() As SpecSuite
     
     With Specs.It("ExtractHeaders should extract multi-line headers from response headers")
         Set Response = New WebResponse
-        ResponseHeaders = "Connection: keep-alive" & vbCrLf & _
-            "Date: Tue, 18 Feb 2014 15:00:26 GMT" & vbCrLf & _
-            "WWW-Authenticate: Digest realm=""abc@host.com""" & vbCrLf & _
-            "nonce=""abc""" & vbCrLf & _
-            "qop=auth" & vbCrLf & _
-            "opaque=""abc""" & vbCrLf & _
+        ResponseHeaders = "Connection: keep-alive" & web_CrLf & _
+            "Date: Tue, 18 Feb 2014 15:00:26 GMT" & web_CrLf & _
+            "WWW-Authenticate: Digest realm=""abc@host.com""" & web_CrLf & _
+            "nonce=""abc""" & web_CrLf & _
+            "qop=auth" & web_CrLf & _
+            "opaque=""abc""" & web_CrLf & _
             "Set-Cookie: cookie=simple-cookie; Path=/"
 
         Set Headers = Response.ExtractHeaders(ResponseHeaders)
         .Expect(Headers.Count).ToEqual 4
         .Expect(Headers.Item(3)("Key")).ToEqual "WWW-Authenticate"
-        .Expect(Headers.Item(3)("Value")).ToEqual "Digest realm=""abc@host.com""" & vbCrLf & _
-            "nonce=""abc""" & vbCrLf & _
-            "qop=auth" & vbCrLf & _
+        .Expect(Headers.Item(3)("Value")).ToEqual "Digest realm=""abc@host.com""" & web_CrLf & _
+            "nonce=""abc""" & web_CrLf & _
+            "qop=auth" & web_CrLf & _
             "opaque=""abc"""
     End With
     
@@ -231,14 +234,14 @@ Public Function Specs() As SpecSuite
     ' --------------------------------------------- '
     With Specs.It("should extract cookies from response headers")
         Set Response = New WebResponse
-        ResponseHeaders = "Connection: keep -alive" & vbCrLf & _
-            "Date: Tue, 18 Feb 2014 15:00:26 GMT" & vbCrLf & _
-            "Content-Length: 2" & vbCrLf & _
-            "Content-Type: text/plain" & vbCrLf & _
-            "Set-Cookie: unsigned-cookie=simple-cookie; Path=/" & vbCrLf & _
-            "Set-Cookie: signed-cookie=s%3Aspecial-cookie.1Ghgw2qpDY93QdYjGFPDLAsa3%2FI0FCtO%2FvlxoHkzF%2BY; Path=/" & vbCrLf & _
-            "Set-Cookie: duplicate-cookie=A; Path=/" & vbCrLf & _
-            "Set-Cookie: duplicate-cookie=B" & vbCrLf & _
+        ResponseHeaders = "Connection: keep -alive" & web_CrLf & _
+            "Date: Tue, 18 Feb 2014 15:00:26 GMT" & web_CrLf & _
+            "Content-Length: 2" & web_CrLf & _
+            "Content-Type: text/plain" & web_CrLf & _
+            "Set-Cookie: unsigned-cookie=simple-cookie; Path=/" & web_CrLf & _
+            "Set-Cookie: signed-cookie=s%3Aspecial-cookie.1Ghgw2qpDY93QdYjGFPDLAsa3%2FI0FCtO%2FvlxoHkzF%2BY; Path=/" & web_CrLf & _
+            "Set-Cookie: duplicate-cookie=A; Path=/" & web_CrLf & _
+            "Set-Cookie: duplicate-cookie=B" & web_CrLf & _
             "X-Powered-By: Express"
 
         Set Headers = Response.ExtractHeaders(ResponseHeaders)
@@ -249,8 +252,8 @@ Public Function Specs() As SpecSuite
     
     With Specs.It("should use RFC 6265 for decoding cookies")
         Set Response = New WebResponse
-        ResponseHeaders = "Set-Cookie: a=plus+plus" & vbCrLf & _
-            "Set-Cookie: b=""quotes""" & vbCrLf & _
+        ResponseHeaders = "Set-Cookie: a=plus+plus" & web_CrLf & _
+            "Set-Cookie: b=""quotes""" & web_CrLf & _
             "Set-Cookie: c=semi-colon; Path=/"
 
         Set Headers = Response.ExtractHeaders(ResponseHeaders)

--- a/src/WebResponse.cls
+++ b/src/WebResponse.cls
@@ -38,6 +38,8 @@ Attribute VB_Exposed = True
 '' ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ '
 Option Explicit
 
+Private web_CrLf As String
+
 ' --------------------------------------------- '
 ' Properties
 ' --------------------------------------------- '
@@ -168,7 +170,7 @@ Public Sub CreateFromCurl(Client As WebClient, Request As WebRequest, Result As 
 
     Dim web_Lines() As String
 
-    web_Lines = VBA.Split(Result, vbCrLf)
+    web_Lines = VBA.Split(Result, web_CrLf)
 
     Me.StatusCode = web_ExtractStatusFromCurlResponse(web_Lines)
     Me.StatusDescription = web_ExtractStatusTextFromCurlResponse(web_Lines)
@@ -208,7 +210,7 @@ Public Function ExtractHeaders(ResponseHeaders As String) As Collection
     Dim web_ColonPosition As Long
     Dim web_Multiline As Boolean
 
-    web_Lines = VBA.Split(ResponseHeaders, vbCrLf)
+    web_Lines = VBA.Split(ResponseHeaders, web_CrLf)
 
     For web_i = LBound(web_Lines) To (UBound(web_Lines) + 1)
         If web_i > UBound(web_Lines) Then
@@ -233,7 +235,7 @@ Public Function ExtractHeaders(ResponseHeaders As String) As Collection
                     Value:=VBA.Trim(VBA.Mid$(web_Lines(web_i), web_ColonPosition + 1, VBA.Len(web_Lines(web_i)))) _
                 )
             Else
-                web_Header("Value") = web_Header("Value") & vbCrLf & web_Lines(web_i)
+                web_Header("Value") = web_Header("Value") & web_CrLf & web_Lines(web_i)
             End If
         End If
     Next web_i
@@ -355,7 +357,7 @@ Private Function web_ExtractHeadersFromCurlResponse(web_CurlResponseLines() As S
         web_WriteIndex = web_WriteIndex + 1
     Next web_ReadIndex
 
-    web_ExtractHeadersFromCurlResponse = VBA.Join$(web_HeaderLines, vbCrLf)
+    web_ExtractHeadersFromCurlResponse = VBA.Join$(web_HeaderLines, web_CrLf)
 End Function
 
 Private Function web_ExtractResponseTextFromCurlResponse(web_CurlResponseLines() As String) As String
@@ -376,7 +378,7 @@ Private Function web_ExtractResponseTextFromCurlResponse(web_CurlResponseLines()
         web_WriteIndex = web_WriteIndex + 1
     Next web_ReadIndex
 
-    web_ExtractResponseTextFromCurlResponse = VBA.Join$(web_BodyLines, vbCrLf)
+    web_ExtractResponseTextFromCurlResponse = VBA.Join$(web_BodyLines, web_CrLf)
 End Function
 
 Private Function web_FindStatusLine(web_CurlResponseLines() As String) As Long
@@ -400,6 +402,8 @@ Private Function web_FindBlankLine(web_CurlResponseLines() As String) As Long
 End Function
 
 Private Sub Class_Initialize()
+    web_CrLf = VBA.Chr$(13) & VBA.Chr$(10)
+
     Set Headers = New Collection
     Set Cookies = New Collection
 End Sub


### PR DESCRIPTION
`vbCrLf` is reversed on Excel for Mac 2016, causing parsing issues with cURL response handling. Fixes #174 