### PR TITLE
Namespace WebHelpers calls

### DIFF
--- a/credentials - example.txt
+++ b/credentials - example.txt
@@ -17,7 +17,7 @@ Google
 
 Salesforce
 # Url: developer.force.com
-# Instructions: https://github.com/timhall/Excel-REST/blob/master/examples/salesforce/Setup%20Salesforce.md
+# Instructions: https://github.com/VBA-tools/VBA-Web/blob/master/examples/salesforce/Setup%20Salesforce.md
 - username: Your username
 - token: Your security token
 - key: Your API key

--- a/specs/Specs_OAuth1Authenticator.bas
+++ b/specs/Specs_OAuth1Authenticator.bas
@@ -85,8 +85,8 @@ Public Function Specs() As SpecSuite
     Auth.Timestamp = "123456789"
     
     ExpectedBaseString = "GET" & "&" & _
-        UrlEncode("http://localhost:3000/testing") & "&" & _
-        UrlEncode("a=123&b=456" & _
+        WebHelpers.UrlEncode("http://localhost:3000/testing") & "&" & _
+        WebHelpers.UrlEncode("a=123&b=456" & _
             "&oauth_consumer_key=" & ConsumerKey & _
             "&oauth_nonce=1234&oauth_signature_method=HMAC-SHA1&oauth_timestamp=123456789" & _
             "&oauth_token=" & Token & _

--- a/specs/Specs_WebAsyncWrapper.bas
+++ b/specs/Specs_WebAsyncWrapper.bas
@@ -1,7 +1,7 @@
 Attribute VB_Name = "Specs_WebAsyncWrapper"
 ''
 ' Specs_WebAsyncWrapper
-' (c) Tim Hall - https://github.com/timhall/Excel-REST
+' (c) Tim Hall - https://github.com/VBA-tools/VBA-Web
 '
 ' Specs for WebAsyncWrapper
 '

--- a/src/WebAsyncWrapper.cls
+++ b/src/WebAsyncWrapper.cls
@@ -129,7 +129,7 @@ End Function
 '
 ' @internal
 ' @method PrepareAndExecuteRequest
-' @param {RestRequest} Request
+' @param {WebRequest} Request
 ' @param {String} Callback
 ' @param {Variant} [CallbackArgs]
 ''
@@ -181,8 +181,8 @@ Private Sub web_RunCallback(web_Response As WebResponse)
     ' Run callback function (needs to be a public function),
     ' passing in response and any defined callback arguments
     '
-    ' callback({RestResponse})
-    ' OR callback({RestResponse}, {Variant})
+    ' callback({WebResponse})
+    ' OR callback({WebResponse}, {Variant})
     '
     ' Example:
     ' Public Function Callback(Response As WebResponse, Args As Variant)

--- a/src/WebClient.cls
+++ b/src/WebClient.cls
@@ -347,7 +347,7 @@ End Function
 ' Set Response = Client.GetJson(Url)
 '
 ' Dim Headers As New Collection
-' Headers.Add RestHelpers.CreateKeyValue("Authorization", "Bearer ...")
+' Headers.Add WebHelpers.CreateKeyValue("Authorization", "Bearer ...")
 '
 ' Dim Options As New Dictionary
 ' Options.Add "Headers", Headers
@@ -393,7 +393,7 @@ End Function
 ' Set Response = Client.PostJson(Url, Body)
 '
 ' Dim Headers As New Collection
-' Headers.Add RestHelpers.CreateKeyValue("Authorization", "Bearer ...")
+' Headers.Add WebHelpers.CreateKeyValue("Authorization", "Bearer ...")
 '
 ' Dim Options As New Dictionary
 ' Options.Add "Headers", Headers

--- a/src/WebClient.cls
+++ b/src/WebClient.cls
@@ -717,7 +717,7 @@ Private Sub web_LoadAutoProxy(web_Request As WebRequest)
 
 web_ErrorHandling:
 
-    LogError "An error occurred while loading auto-proxy" & vbNewLine & _
+    WebHelpers.LogError "An error occurred while loading auto-proxy" & vbNewLine & _
         Err.Number & VBA.IIf(Err.Number < 0, " (" & VBA.LCase$(VBA.Hex$(Err.Number)) & ")", "") & ": " & Err.Description, _
         "WebClient.LoadAutoProxy", Err.Number
 #End If


### PR DESCRIPTION
Avoid name collisions with WebHelpers methods by namespacing methods as needed (e.g. `LogError -> WebHelpers.LogError`)

Fixes #160 
