### PR TITLE
VB error 438 invalid property or method

### DIFF
--- a/src/WebClient.cls
+++ b/src/WebClient.cls
@@ -543,11 +543,11 @@ Public Function PrepareHttpRequest(Request As WebRequest, Optional Async As Bool
 
     ' Set headers on http request (after open)
     For Each web_KeyValue In Request.Headers
-        web_Http.SetRequestHeader web_KeyValue("Key"), web_KeyValue("Value")
+        web_Http.SetRequestHeader web_KeyValue.Item("Key"), web_KeyValue.Item("Value")
     Next web_KeyValue
 
     For Each web_KeyValue In Request.Cookies
-        web_Http.SetRequestHeader "Cookie", web_KeyValue("Key") & "=" & web_KeyValue("Value")
+        web_Http.SetRequestHeader "Cookie", web_KeyValue.Item("Key") & "=" & web_KeyValue.Item("Value")
     Next web_KeyValue
 
     ' Give authenticator opportunity to update Http

--- a/src/WebHelpers.bas
+++ b/src/WebHelpers.bas
@@ -626,7 +626,7 @@ Public Function ConvertToUrlEncoded(Obj As Variant) As String
 
         For Each web_Key In Obj.Keys()
             If Len(web_Encoded) > 0 Then: web_Encoded = web_Encoded & "&"
-            web_Encoded = web_Encoded & web_GetUrlEncodedKeyValue(web_Key, Obj(web_Key))
+            web_Encoded = web_Encoded & web_GetUrlEncodedKeyValue(web_Key, Obj.Item(web_Key))
         Next web_Key
     End If
 
@@ -1238,7 +1238,7 @@ Public Function CloneDictionary(Original As Dictionary) As Dictionary
 
     Set CloneDictionary = New Dictionary
     For Each web_Key In Original.Keys
-        CloneDictionary.Add VBA.CStr(web_Key), Original(web_Key)
+        CloneDictionary.Add VBA.CStr(web_Key), Original.Item(web_Key)
     Next web_Key
 End Function
 
@@ -1279,8 +1279,8 @@ End Function
 Public Function CreateKeyValue(Key As String, Value As Variant) As Dictionary
     Dim web_KeyValue As New Dictionary
 
-    web_KeyValue("Key") = Key
-    web_KeyValue("Value") = Value
+    web_KeyValue.Item("Key") = Key
+    web_KeyValue.Item("Value") = Value
     Set CreateKeyValue = web_KeyValue
 End Function
 
@@ -1353,7 +1353,7 @@ Public Sub AddOrReplaceInKeyValues(KeyValues As Collection, Key As Variant, Valu
 
     web_Index = 1
     For Each web_KeyValue In KeyValues
-        If web_KeyValue("Key") = Key Then
+        If web_KeyValue.Item("Key") = Key Then
             ' Replace existing
             KeyValues.Remove web_Index
 

--- a/src/WebRequest.cls
+++ b/src/WebRequest.cls
@@ -502,7 +502,7 @@ Public Property Get FormattedResource() As String
 
     ' Replace url segments
     For Each web_Segment In Me.UrlSegments.Keys
-        FormattedResource = VBA.Replace(FormattedResource, "{" & web_Segment & "}", WebHelpers.UrlEncode(Me.UrlSegments(web_Segment)))
+        FormattedResource = VBA.Replace(FormattedResource, "{" & web_Segment & "}", WebHelpers.UrlEncode(Me.UrlSegments.Item(web_Segment)))
     Next web_Segment
 
     ' Add querystring
@@ -691,9 +691,9 @@ Public Sub AddBodyParameter(Key As Variant, Value As Variant)
     End If
 
     If VBA.IsObject(Value) Then
-        Set web_pBody(Key) = Value
+        Set web_pBody.Item(Key) = Value
     Else
-        web_pBody(Key) = Value
+        web_pBody.Item(Key) = Value
     End If
 
     ' Clear cached converted body


### PR DESCRIPTION
When I use this code in Outlook, I get the following VB error when I use WebRequest.AddBodyParameter.

```
Run-time error '438':

Object doesn't support this property or method
```

I didn't import the Dictionary module but instead copied the code from a module in another project - and in doing so lost the default property attribute.

This PR adds explicit Item calls in order to avoid this happening to other users.