### PR TITLE
Add conditional error-handling

### DIFF
--- a/authenticators/FacebookAuthenticator.cls
+++ b/authenticators/FacebookAuthenticator.cls
@@ -82,7 +82,9 @@ End Sub
 ' Login to Facebook
 ''
 Public Sub Login()
-    On Error GoTo auth_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo auth_ErrorHandling
+    End If
     
     Dim auth_Completed As Boolean
 

--- a/authenticators/GoogleAuthenticator.cls
+++ b/authenticators/GoogleAuthenticator.cls
@@ -91,7 +91,9 @@ End Sub
 ' Login to Google
 ''
 Public Sub Login()
-    On Error GoTo auth_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo auth_ErrorHandling
+    End If
     
     ' No need to login if API key, authorization code, or token have been set
     If Me.ApiKey <> "" Or Me.AuthorizationCode <> "" Or Me.Token <> "" Then
@@ -127,7 +129,9 @@ Public Sub Login()
 #Else
 
     ' Windows login uses IE to automate retrieving authorization code for user
-    On Error GoTo auth_Cleanup
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo auth_Cleanup
+    End If
     
     Dim auth_IE As Object
     auth_Completed = False
@@ -287,7 +291,9 @@ End Sub
 ' @return {String}
 ''
 Public Function GetToken(Client As WebClient) As String
-    On Error GoTo auth_Cleanup
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo auth_Cleanup
+    End If
     
     Dim auth_TokenClient As WebClient
     Dim auth_Request As New WebRequest

--- a/authenticators/OAuth2Authenticator.cls
+++ b/authenticators/OAuth2Authenticator.cls
@@ -114,7 +114,9 @@ Public Function GetToken(auth_Client As WebClient) As String
     ' TODO Generalize flow
     ' [Digging Deeper into OAuth 2.0 on Force.com](http://wiki.developerforce.com/page/Digging_Deeper_into_OAuth_2.0_at_Salesforce.com)
     
-    On Error GoTo auth_Cleanup
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo auth_Cleanup
+    End If
     
     Dim auth_TokenClient As WebClient
     Dim auth_Request As New WebRequest

--- a/authenticators/TodoistAuthenticator.cls
+++ b/authenticators/TodoistAuthenticator.cls
@@ -94,7 +94,9 @@ End Sub
 ' Login
 ''
 Public Sub Login()
-    On Error GoTo auth_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo auth_ErrorHandling
+    End If
 
     ' Don't need to login if we already have authorization code or token
     If Me.AuthorizationCode <> "" Or Me.Token <> "" Then
@@ -123,7 +125,9 @@ Public Sub Login()
     Me.Token = auth_Response
 #Else
     ' Windows login uses IE to automate retrieving authorization code for user
-    On Error GoTo auth_Cleanup
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo auth_Cleanup
+    End If
 
     Dim auth_IE As Object
     auth_Completed = False
@@ -266,7 +270,9 @@ End Sub
 ' @return {String}
 ''
 Public Function GetToken(Client As WebClient) As String
-    On Error GoTo auth_Cleanup
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo auth_Cleanup
+    End If
     
     Dim auth_TokenClient As WebClient
     Dim auth_Request As New WebRequest

--- a/authenticators/TwitterAuthenticator.cls
+++ b/authenticators/TwitterAuthenticator.cls
@@ -111,7 +111,9 @@ End Sub
 ' @return {String}
 ''
 Public Function GetToken(auth_Client As WebClient) As String
-    On Error GoTo auth_Cleanup
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo auth_Cleanup
+    End If
     
     Dim auth_TokenClient As WebClient
     Dim auth_Request As New WebRequest

--- a/src/WebAsyncWrapper.cls
+++ b/src/WebAsyncWrapper.cls
@@ -134,7 +134,9 @@ End Function
 ' @param {Variant} [CallbackArgs]
 ''
 Public Sub PrepareAndExecuteRequest(Request As WebRequest, Callback As String, Optional ByVal CallbackArgs As Variant)
-    On Error GoTo web_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo web_ErrorHandling
+    End If
 
     Me.Callback = Callback
     Me.CallbackArgs = CallbackArgs

--- a/src/WebClient.cls
+++ b/src/WebClient.cls
@@ -243,7 +243,9 @@ Public Function Execute(Request As WebRequest) As WebResponse
     Dim web_Http As Object
     Dim web_Response As New WebResponse
 
-    On Error GoTo web_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo web_ErrorHandling
+    End If
 
 #If Mac Then
     Dim web_Curl As String
@@ -482,7 +484,9 @@ Public Function PrepareHttpRequest(Request As WebRequest, Optional Async As Bool
     Dim web_Http As Object
     Dim web_KeyValue As Dictionary
 
-    On Error GoTo web_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo web_ErrorHandling
+    End If
 
     Set web_Http = CreateObject("WinHttp.WinHttpRequest.5.1")
 
@@ -582,7 +586,9 @@ Public Function PrepareCurlRequest(Request As WebRequest) As String
     Dim web_KeyValue As Dictionary
     Dim web_CookieString As String
 
-    On Error GoTo web_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo web_ErrorHandling
+    End If
 
     web_Curl = "curl -i"
 
@@ -686,7 +692,9 @@ End Sub
 
 Private Sub web_LoadAutoProxy(web_Request As WebRequest)
 #If Win32 Or Win64 Then
-    On Error GoTo web_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+       GoTo web_ErrorHandling
+    End If
 
     Dim web_Parts As Dictionary
     Dim web_Domain As String

--- a/src/WebHelpers.bas
+++ b/src/WebHelpers.bas
@@ -50,6 +50,10 @@ Option Explicit
 ' you can disable custom formatting by setting the following compiler flag to False
 #Const EnableCustomFormatting = True
 
+' Setting WebDebug to True disables all On Error statements which goto error handlers
+' enabling debugging of VBA-Web code.
+Public WebDebug As Boolean
+
 ' === AutoProxy Headers
 #If Mac Then
 #ElseIf VBA7 Then
@@ -765,7 +769,9 @@ End Function
 ' @throws 11001 - Error during conversion
 ''
 Public Function ConvertToFormat(Obj As Variant, Format As WebFormat, Optional CustomFormat As String = "") As Variant
-    On Error GoTo web_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo web_ErrorHandling
+    End If
 
     Select Case Format
     Case WebFormat.Json
@@ -1119,7 +1125,9 @@ End Function
 Public Function GetUrlParts(Url As String) As Dictionary
     Dim web_Parts As New Dictionary
 
-    On Error GoTo web_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo web_ErrorHandling
+    End If
 
 #If Mac Then
     ' Run perl script to parse url
@@ -1470,7 +1478,9 @@ Public Function ExecuteInShell(web_Command As String) As ShellResult
     Dim web_Chunk As String
     Dim web_Read As Long
 
-    On Error GoTo web_Cleanup
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo web_Cleanup
+    End If
 
     web_File = web_popen(web_Command, "r")
 
@@ -2462,7 +2472,9 @@ End Function
 ' @throws 10011 - UTC parsing error
 ''
 Public Function ParseUtc(utc_UtcDate As Date) As Date
-    On Error GoTo utc_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo utc_ErrorHandling
+    End If
 
 #If Mac Then
     ParseUtc = utc_ConvertDate(utc_UtcDate)
@@ -2491,7 +2503,9 @@ End Function
 ' @throws 10012 - UTC conversion error
 ''
 Public Function ConvertToUtc(utc_LocalDate As Date) As Date
-    On Error GoTo utc_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo utc_ErrorHandling
+    End If
 
 #If Mac Then
     ConvertToUtc = utc_ConvertDate(utc_LocalDate, utc_ConvertToUtc:=True)
@@ -2596,7 +2610,9 @@ End Function
 ' @throws 10014 - ISO 8601 conversion error
 ''
 Public Function ConvertToIso(utc_LocalDate As Date) As String
-    On Error GoTo utc_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo utc_ErrorHandling
+    End If
 
     ConvertToIso = VBA.Format$(ConvertToUtc(utc_LocalDate), "yyyy-mm-ddTHH:mm:ss.000Z")
 
@@ -2648,7 +2664,9 @@ Private Function utc_ExecuteInShell(utc_ShellCommand As String) As utc_ShellResu
     Dim utc_Chunk As String
     Dim utc_Read As Long
 
-    On Error GoTo utc_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo utc_ErrorHandling
+    End If
     utc_File = utc_popen(utc_ShellCommand, "r")
 
     If utc_File = 0 Then: Exit Function
@@ -2742,7 +2760,9 @@ Public Sub GetAutoProxy(ByVal Url As String, ByRef ProxyServer As String, ByRef 
     ' WinHttpGetProxyForUrl returns unexpected errors if Url is empty
     If Url = "" Then Url = " "
 
-    On Error GoTo AutoProxy_Cleanup
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo AutoProxy_Cleanup
+    End If
 
     ' Check IE's proxy configuration
     If (AutoProxy_GetIEProxy(AutoProxy_IEProxyConfig) > 0) Then

--- a/src/WebResponse.cls
+++ b/src/WebResponse.cls
@@ -134,7 +134,9 @@ End Sub
 ' @throws 11030 / 80042b16 / -2147210474 - Error creating from http
 ''
 Public Sub CreateFromHttp(Client As WebClient, Request As WebRequest, Http As Object)
-    On Error GoTo web_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo web_ErrorHandling
+    End If
 
     Me.StatusCode = Http.Status
     Me.StatusDescription = Http.StatusText
@@ -166,7 +168,9 @@ End Sub
 ' @throws 11031 / 80042b17 / -2147210473 - Error creating from cURL
 ''
 Public Sub CreateFromCurl(Client As WebClient, Request As WebRequest, Result As String)
-    On Error GoTo web_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo web_ErrorHandling
+    End If
 
     Dim web_Lines() As String
 
@@ -201,7 +205,9 @@ End Sub
 ' @throws 11032 / 80042b18 / -2147210472 - Error extracting headers
 ''
 Public Function ExtractHeaders(ResponseHeaders As String) As Collection
-    On Error GoTo web_ErrorHandling
+    If Not WebHelpers.WebDebug Then
+        On Error GoTo web_ErrorHandling
+    End If
 
     Dim web_Lines As Variant
     Dim web_i As Integer


### PR DESCRIPTION
This PR adds a `Public Constant WebDebug` in WebHelpers.

When this is set to true, most `On Error` statements are not executed, allowing for easier debugging of VBA-Web code.