### PR TITLE
WaitForResponse is in seconds

### DIFF
--- a/src/WebClient.cls
+++ b/src/WebClient.cls
@@ -291,7 +291,7 @@ Public Function Execute(Request As WebRequest) As WebResponse
     Set web_Http = Me.PrepareHttpRequest(Request)
 
     web_Http.Send Request.Body
-    Do While Not web_Http.WaitForResponse(25)
+    Do While Not web_Http.WaitForResponse(0.025)
         VBA.DoEvents
     Loop
 


### PR DESCRIPTION
Doing a loop for 25ms and then issuing a DoEvents makes sense.

But according to [Microsoft](https://msdn.microsoft.com/en-us/library/windows/desktop/aa384064%28v=vs.85%29.aspx) the parameter is measured in seconds and a 25sec loop does not make sense. 

This PR reduces it to 0.025 i.e. 25ms which makes more sense.