### PR TITLE
Correct UrlEncoding per spec

### DIFF
--- a/src/WebHelpers.bas
+++ b/src/WebHelpers.bas
@@ -850,20 +850,21 @@ Public Function UrlEncode(Text As Variant, Optional SpaceAsPlus As Boolean = Fal
             web_CharCode = VBA.Asc(web_Char)
 
             Select Case web_CharCode
-            Case 36, 38, 43, 44, 47, 58, 59, 61, 63, 64
-                ' Reserved characters
-                web_Result(web_i) = "%" & VBA.Hex(web_CharCode)
-            Case 32
-                web_Result(web_i) = web_Space
-            Case 34, 35, 37, 60, 62, 91 To 94, 96, 123 To 126
-                ' Unsafe characters
-                If EncodeUnsafe Then
-                    web_Result(web_i) = "%" & VBA.Hex(web_CharCode)
-                Else
+                Case 97 To 122, 65 To 90, 48 To 57, 45, 46, 95, 126
                     web_Result(web_i) = web_Char
-                End If
-            Case Else
-                web_Result(web_i) = web_Char
+                Case 32
+                    web_Result(web_i) = web_Space
+                Case 0 To 15
+                    web_Result(web_i) = "%0" & Hex(web_CharCode)
+                Case 34, 35, 37, 60, 62, 91 To 94, 96, 123 To 126
+                    ' Unsafe characters
+                    If EncodeUnsafe Then
+                        web_Result(web_i) = "%" & VBA.Hex(web_CharCode)
+                    Else
+                        web_Result(web_i) = web_Char
+                    End If
+                Case Else
+                    web_Result(web_i) = "%0" & Hex(web_CharCode)
             End Select
         Next web_i
         UrlEncode = VBA.Join$(web_Result, "")

--- a/src/WebHelpers.bas
+++ b/src/WebHelpers.bas
@@ -855,7 +855,7 @@ Public Function UrlEncode(Text As Variant, Optional SpaceAsPlus As Boolean = Fal
                 Case 32
                     web_Result(web_i) = web_Space
                 Case 0 To 15
-                    web_Result(web_i) = "%0" & Hex(web_CharCode)
+                    web_Result(web_i) = "%0" & VBA.Hex(web_CharCode)
                 Case 34, 35, 37, 60, 62, 91 To 94, 96, 123 To 126
                     ' Unsafe characters
                     If EncodeUnsafe Then
@@ -864,7 +864,7 @@ Public Function UrlEncode(Text As Variant, Optional SpaceAsPlus As Boolean = Fal
                         web_Result(web_i) = web_Char
                     End If
                 Case Else
-                    web_Result(web_i) = "%0" & Hex(web_CharCode)
+                    web_Result(web_i) = "%" & VBA.Hex(web_CharCode)
             End Select
         Next web_i
         UrlEncode = VBA.Join$(web_Result, "")


### PR DESCRIPTION
UrlEncode does not encode all characters that should be encoded as per spec. [RFC 1738](https://www.ietf.org/rfc/rfc1738.txt) states 

>Octets must be encoded if they have no corresponding graphic character within the US-ASCII coded character set, if the use of the corresponding character is unsafe, or if the corresponding character is reserved for some other interpretation within the particular URL scheme. No corresponding graphic US-ASCII: URLs are written only with the graphic printable characters of the US-ASCII coded character set. The octets 80-FF hexadecimal are not used in US-ASCII, and the octets 00-1F and 7F hexadecimal represent control characters; these must be encoded. 

See also [W3Schools HTML URL Encoding Reference](http://www.w3schools.com/tags/ref_urlencode.asp) and [StackOverflow How can I URL encode a string in Excel VBA? EDIT2](http://stackoverflow.com/questions/218181/how-can-i-url-encode-a-string-in-excel-vba).