### PR TITLE
Update Cookie Encoding

### DIFF
--- a/specs/Specs_WebHelpers.bas
+++ b/specs/Specs_WebHelpers.bas
@@ -311,30 +311,37 @@ Public Function Specs() As SpecSuite
         .Expect(WebHelpers.UrlEncode("_", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "_"
         .Expect(WebHelpers.UrlEncode("~", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "~"
         
+        ' Note: "%" is allowed in spec, but is currently excluded due to parsing issues
         .Expect(WebHelpers.UrlEncode("%", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%25"
+        
+        .Expect(WebHelpers.UrlEncode("""", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%22"
         .Expect(WebHelpers.UrlEncode(" ", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%20"
-
+        
         .Expect(WebHelpers.UrlEncode("!", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "!"
         .Expect(WebHelpers.UrlEncode("#", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "#"
         .Expect(WebHelpers.UrlEncode("$", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "$"
         .Expect(WebHelpers.UrlEncode("&", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "&"
         .Expect(WebHelpers.UrlEncode("'", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "'"
-        .Expect(WebHelpers.UrlEncode("(", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%28"
-        .Expect(WebHelpers.UrlEncode(")", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%29"
+        .Expect(WebHelpers.UrlEncode("(", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "("
+        .Expect(WebHelpers.UrlEncode(")", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual ")"
         .Expect(WebHelpers.UrlEncode("*", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "*"
         .Expect(WebHelpers.UrlEncode("+", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "+"
         .Expect(WebHelpers.UrlEncode(",", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%2C"
-        .Expect(WebHelpers.UrlEncode("/", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%2F"
-        .Expect(WebHelpers.UrlEncode(":", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%3A"
+        .Expect(WebHelpers.UrlEncode("/", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "/"
+        .Expect(WebHelpers.UrlEncode(":", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual ":"
         .Expect(WebHelpers.UrlEncode(";", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%3B"
-        .Expect(WebHelpers.UrlEncode("=", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%3D"
-        .Expect(WebHelpers.UrlEncode("?", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%3F"
-        .Expect(WebHelpers.UrlEncode("@", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%40"
-        .Expect(WebHelpers.UrlEncode("[", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%5B"
-        .Expect(WebHelpers.UrlEncode("]", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "%5D"
+        .Expect(WebHelpers.UrlEncode("<", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "<"
+        .Expect(WebHelpers.UrlEncode("=", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "="
+        .Expect(WebHelpers.UrlEncode(">", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual ">"
+        .Expect(WebHelpers.UrlEncode("?", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "?"
+        .Expect(WebHelpers.UrlEncode("@", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "@"
+        .Expect(WebHelpers.UrlEncode("[", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "["
+        .Expect(WebHelpers.UrlEncode("]", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "]"
         .Expect(WebHelpers.UrlEncode("^", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "^"
         .Expect(WebHelpers.UrlEncode("`", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "`"
+        .Expect(WebHelpers.UrlEncode("{", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "{"
         .Expect(WebHelpers.UrlEncode("|", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "|"
+        .Expect(WebHelpers.UrlEncode("}", EncodingMode:=UrlEncodingMode.CookieUrlEncoding)).ToEqual "}"
     End With
 
     With Specs.It("should url-encode (PathUrlEncoding)")

--- a/specs/Specs_WebRequest.bas
+++ b/specs/Specs_WebRequest.bas
@@ -338,11 +338,11 @@ Public Function Specs() As SpecSuite
     With Specs.It("should AddCookie")
         Set Request = New WebRequest
         
-        Request.AddCookie "A", "cookie"
+        Request.AddCookie "A[1]", "cookie"
         Request.AddCookie "B", "cookie 2"
         
         .Expect(Request.Cookies.Count).ToEqual 2
-        .Expect(Request.Cookies(1)("Key")).ToEqual "A"
+        .Expect(Request.Cookies(1)("Key")).ToEqual "A%5B1%5D"
         .Expect(Request.Cookies(2)("Value")).ToEqual "cookie%202"
     End With
     

--- a/src/WebRequest.cls
+++ b/src/WebRequest.cls
@@ -678,7 +678,7 @@ End Sub
 ''
 Public Sub AddCookie(Key As String, Value As Variant)
     Me.Cookies.Add WebHelpers.CreateKeyValue( _
-        Key, _
+        web_EncodeCookieName(Key), _
         WebHelpers.UrlEncode(Value, EncodingMode:=UrlEncodingMode.CookieUrlEncoding) _
     )
 End Sub
@@ -809,6 +809,55 @@ End Sub
 ' ============================================= '
 ' Private Functions
 ' ============================================= '
+
+' Encode cookie name
+'
+' References:
+' - RFC 6265 https://tools.ietf.org/html/rfc6265
+Private Function web_EncodeCookieName(web_CookieName As Variant) As String
+    Dim web_CookieVal As String
+    Dim web_StringLen As Long
+
+    web_CookieVal = VBA.CStr(web_CookieName)
+    web_StringLen = VBA.Len(web_CookieVal)
+
+    If web_StringLen > 0 Then
+        Dim web_Result() As String
+        Dim web_i As Long
+        Dim web_CharCode As Integer
+        Dim web_Char As String
+        ReDim web_Result(web_StringLen)
+
+        ' ALPHA / DIGIT / "!" / "#" / "$" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+        ' Note: "%" is allowed in spec, but is currently excluded due to parsing issues
+
+        ' Loop through string characters
+        For web_i = 1 To web_StringLen
+            ' Get character and ascii code
+            web_Char = VBA.Mid$(web_CookieVal, web_i, 1)
+            web_CharCode = VBA.Asc(web_Char)
+
+            Select Case web_CharCode
+                Case 65 To 90, 97 To 122
+                    ' ALPHA
+                    web_Result(web_i) = web_Char
+                Case 48 To 57
+                    ' DIGIT
+                    web_Result(web_i) = web_Char
+                Case 33, 35, 36, 38, 39, 42, 43, 45, 46, 94, 95, 96, 124, 126
+                    ' "!" / "#" / "$" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+                    web_Result(web_i) = web_Char
+                
+                Case 0 To 15
+                    web_Result(web_i) = "%0" & VBA.Hex(web_CharCode)
+                Case Else
+                    web_Result(web_i) = "%" & VBA.Hex(web_CharCode)
+            End Select
+        Next web_i
+        
+        web_EncodeCookieName = VBA.Join$(web_Result, "")
+    End If
+End Function
 
 Private Sub Class_Initialize()
     ' Set default values

--- a/src/WebRequest.cls
+++ b/src/WebRequest.cls
@@ -678,7 +678,7 @@ End Sub
 ''
 Public Sub AddCookie(Key As String, Value As Variant)
     Me.Cookies.Add WebHelpers.CreateKeyValue( _
-        WebHelpers.UrlEncode(Key, EncodingMode:=UrlEncodingMode.CookieUrlEncoding), _
+        Key, _
         WebHelpers.UrlEncode(Value, EncodingMode:=UrlEncodingMode.CookieUrlEncoding) _
     )
 End Sub


### PR DESCRIPTION
Was using the name encoding for both the name and value of the cookie, which is much more strict than value encoding in RFC 6265.

```
(RFC 6265)
cookie-pair       = cookie-name "=" cookie-value
cookie-name       = token
cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
                       ; US-ASCII characters excluding CTLs,
                       ; whitespace DQUOTE, comma, semicolon,
                       ; and backslash
token             = <token, defined in [RFC2616], Section 2.2>

(RFC2616)
token          = 1*<any CHAR except CTLs or separators>
separators     = "(" | ")" | "<" | ">" | "@"
               | "," | ";" | ":" | "\" | <">
               | "/" | "[" | "]" | "?" | "="
               | "{" | "}" | SP | HT
```

```
name = ALPHA / DIGIT / "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / 
  "_" / "`" / "|" / "~"`

value = strict / "!" / "#" / "$" / "%" / "&" / "'" / "(" / ")" / "*" / "+" / "/" / ":" / 
  "<" / "=" / ">" / "?" / "@" / "[" / "]" / "^" / "`" / "{" / "|" / "}"
```

`UrlEncodingMode.CookieUrlEncoding` now uses `value` encoding (and `name` encoding is implemented internally)

Fixes #235 