### PR TITLE
Escape single quotes in json

### DIFF
--- a/src/WebHelpers.bas
+++ b/src/WebHelpers.bas
@@ -2539,11 +2539,15 @@ Private Function json_Encode(ByVal json_Text As Variant) As String
         End If
 
         ' From spec, ", \, and control characters must be escaped (solidus is optional)
-
+        ' To avoid problems with quoting the payload on the command line in single quotes, need to escape ' also
+        
         Select Case json_AscCode
         Case 34
             ' " -> 34 -> \"
             json_Char = "\"""
+        Case 39
+            ' ' -> 39 -> \u0027  (decimal 39 is 27 in hex)
+            json_Char = "\u0027"
         Case 92
             ' \ -> 92 -> \\
             json_Char = "\\"


### PR DESCRIPTION
When the json ends up as a payload in a curl command, the single quotes will mess things up.

So, really, this is a curl specific issue.  I looked at doing a replace for single quotes in the PrepareCurlRequest method, which would make sense.  That is where it is being wrapped in single quotes, so that is where encoding any embedded single quotes is needed.  But, it changes the content length which messes up that header, and in general, it seems like your design is that any encoding has already happened.  So, I'm thinking maybe you want to move this up-stream to each of your encoders -- just make it a rule that single quote is encoded to avoid problems.  Though, that  does mean you'd have to enforce this in each style of encoder and it only actually matters when using curl.  Maybe there's a call back to the request object that the curl method can made to say, "oh hey, make sure to encode any single quotes". 

So, that's why I just proposed this change here instead of in your VBA-JSON repo.  Just getting the ball rolling on where you think the right place is for this fix.

Thanks for all your efforts on this library.  It is nicely designed and just what we were looking for!