### PR TITLE
ISO date parsing with offset doesn't convert correctly

### DIFF
--- a/specs/Specs_WebHelpers.bas
+++ b/specs/Specs_WebHelpers.bas
@@ -25,6 +25,7 @@ Public Function Specs() As SpecSuite
     ' 6. Timing
     ' 7. Mac
     ' 8. Cryptography
+    ' 9. Date/Time conversion
     ' Errors
     ' --------------------------------------------- '
     
@@ -680,6 +681,29 @@ Public Function Specs() As SpecSuite
         .Expect(Len(WebHelpers.CreateNonce)).ToEqual 32
         .Expect(Len(WebHelpers.CreateNonce(20))).ToEqual 20
     End With
+    
+    
+    ' ============================================= '
+    ' 9. Date/Time conversion
+    ' ============================================= '
+    
+    ' ISO to UTC (all ISO dates in daylight saving time)
+    ' --------------------------------------------- '
+    With Specs.It("should handle offset in ISO date")
+        .Expect(WebHelpers.ConvertToUtc(WebHelpers.ParseIso("2017-05-01T02:00:00.000+02:00"))).ToEqual DateValue("2017-05-01") + TimeValue("00:00:00") ' 02:00:00 in Berlin => 00:00 (same day) UTC
+        .Expect(WebHelpers.ConvertToUtc(WebHelpers.ParseIso("2017-05-01T00:00:00.000+02:00"))).ToEqual DateValue("2017-04-30") + TimeValue("22:00:00") ' 00:00:00 in Berlin => 22:00 (prev. day) UTC
+        .Expect(WebHelpers.ConvertToUtc(WebHelpers.ParseIso("2017-04-30T20:00:00.000-04:00"))).ToEqual DateValue("2017-05-01") + TimeValue("00:00:00") ' 20:00:00 in New York => 00:00 (next day) UTC
+    End With
+    
+    ' ISO to UTC
+    ' --------------------------------------------- '
+    With Specs.It("should convert ISO dates in UTC to UTC")
+        .Expect(WebHelpers.ConvertToUtc(WebHelpers.ParseIso("2017-05-01T00:00:00.000Z"))).ToEqual DateValue("2017-05-01 00:00:00") + TimeValue("00:00:00")
+        .Expect(WebHelpers.ConvertToUtc(WebHelpers.ParseIso("2017-05-01T00:00:00.000+00:00"))).ToEqual DateValue("2017-05-01 00:00:00") + TimeValue("00:00:00")
+    End With
+    
+    
+    
     
     ' ============================================= '
     ' Errors

--- a/src/WebHelpers.bas
+++ b/src/WebHelpers.bas
@@ -2918,12 +2918,15 @@ Public Function ParseIso(utc_IsoString As String) As Date
             ' VBA.Val does not use regional settings, use for seconds to avoid decimal/comma issues
             ParseIso = ParseIso + VBA.TimeSerial(VBA.CInt(utc_TimeParts(0)), VBA.CInt(utc_TimeParts(1)), Int(VBA.Val(utc_TimeParts(2))))
         End Select
-
-        ParseIso = ParseUtc(ParseIso)
-
+        
         If utc_HasOffset Then
-            ParseIso = ParseIso + utc_Offset
+            ' if an Offset exists, then compensate for it (by substracting)
+            ParseIso = ParseUtc(ParseIso - utc_Offset)
+        Else
+            ' no Offset => date already in UTC
+            ParseIso = ParseUtc(ParseIso)
         End If
+
     End If
 
     Exit Function


### PR DESCRIPTION
Dear Tim,
first of all thanks for you tremendous work on VBA-Web! 
I believe I found a bug when parsing dates from Webservices using the WebHelpers.ParseIso function:
When an offset is supplied (e.g. +02:00 for Berlin, my time zone), the conversion to local time and to UTC does not work properly. 
For instance (examples also used in specs supplied in pull request):
* 2017-05-01T02:00:00.000+02:00 represents 02:00 (24h format) on 2017-05-01 in Berlin
** the offset specifies, that Berlin is 2 hours ahead of UTC. Hence, **2 hours need to be subtracted** to get UTC.
** The result in UTC should be 2017-05-01T00:00:00.000+00:00
* 2017-05-01T00:00:00.000+02:00 represents 00:00 on 2017-05-01 in Berlin
** substracting 2 hours to get UTC => 2017-04-30T22:00:00.000+00:00

(There is an additional test in the spec for negative offset, time zone of New York).

I hope, this seems plausible and correct to you and you accept my pull request. 

Thanks. 
keyJ

(Sorry for the duplicate commit (a30a0cb and 678811c have the same changes, only commit message is different).