### PR TITLE
do not add headers Content-Type/Content-Length for GET

### DIFF
--- a/src/WebRequest.cls
+++ b/src/WebRequest.cls
@@ -740,9 +740,11 @@ End Sub
 Public Sub Prepare()
     ' Add/replace general headers for request
     SetHeader "User-Agent", Me.UserAgent
-    SetHeader "Content-Type", Me.ContentType
     SetHeader "Accept", Me.Accept
-    SetHeader "Content-Length", VBA.CStr(Me.ContentLength)
+    If Me.Method <> HttpGet Then
+        SetHeader "Content-Type", Me.ContentType
+        SetHeader "Content-Length", VBA.CStr(Me.ContentLength)
+    End If
 End Sub
 
 ''


### PR DESCRIPTION
When using VBA-Web with a standard Flask API server, the server crashed when giving a Content-Type without body to parse (see https://github.com/flask-restful/flask-restful/issues/510).
Maybe better to not send these headers for GET requests