### PR TITLE
[macOS] Fix curl error "argument list too long"

### DIFF
--- a/src/WebClient.cls
+++ b/src/WebClient.cls
@@ -659,10 +659,17 @@ Public Function PrepareCurlRequest(Request As WebRequest) As String
     If web_CookieString <> "" Then
         web_Curl = web_Curl & " --cookie '" & web_CookieString & "'"
     End If
-
-    ' Add method, data, and url
+                                        
+    ' Add method
     web_Curl = web_Curl & " -X " & WebHelpers.MethodToName(Request.Method)
-    web_Curl = web_Curl & " -d '" & Request.Body & "'"
+    
+    ' Add data
+    Open "requestbody.txt" For Output As #1
+    Print #1, Request.Body
+    Close #1
+    web_Curl = web_Curl & " -d @requestbody.txt'" & "'"
+    
+    ' Add url
     web_Curl = web_Curl & " '" & Me.GetFullUrl(Request) & "'"
 
     ' Give authenticator opportunity to update cURL
@@ -670,9 +677,11 @@ Public Function PrepareCurlRequest(Request As WebRequest) As String
         Me.Authenticator.PrepareCurl Me, Request, web_Curl
     End If
 
-    ' Log request and return
+    ' Log request
     WebHelpers.LogRequest Me, Request
-    PrepareCurlRequest = web_Curl
+    
+    ' Remove data file and return
+    PrepareCurlRequest = web_Curl & "&& rm requestbody.txt"
     Exit Function
 
 web_ErrorHandling:


### PR DESCRIPTION
See https://github.com/VBA-tools/VBA-Web/issues/396 for details.
The `requestbody.txt` file is being saved to `/Users/MYSUSER/Library/Containers/com.microsoft.Excel/Data` and will be removed once the `curl` command has been executed.