### PR TITLE
Replaced References to Rest* with Web* in Docs

### DIFF
--- a/docs/_data/docs/WebClient.yml
+++ b/docs/_data/docs/WebClient.yml
@@ -128,7 +128,7 @@ Methods:
       Set Response = Client.GetJson(Url)
       
       Dim Headers As New Collection
-      Headers.Add RestHelpers.CreateKeyValue("Authorization", "Bearer ...")
+      Headers.Add WebHelpers.CreateKeyValue("Authorization", "Bearer ...")
       
       Dim Options As New Dictionary
       Options.Add "Headers", Headers
@@ -163,7 +163,7 @@ Methods:
       Set Response = Client.PostJson(Url, Body)
       
       Dim Headers As New Collection
-      Headers.Add RestHelpers.CreateKeyValue("Authorization", "Bearer ...")
+      Headers.Add WebHelpers.CreateKeyValue("Authorization", "Bearer ...")
       
       Dim Options As New Dictionary
       Options.Add "Headers", Headers
@@ -181,7 +181,7 @@ Methods:
     description: |
       Helper for setting proxy values.
     example: |
-      Dim Client As New RestClient
+      Dim Client As New WebClient
 
       ' Just Server
       Client.SetProxy "proxy_server:80"

--- a/docs/_data/docs/WebRequest.yml
+++ b/docs/_data/docs/WebRequest.yml
@@ -125,7 +125,7 @@ Properties:
 
       (Automatically sets `RequestFormat` to `WebFormat.Custom`)
     example: |
-      RestHelpers.RegisterConverter "csv", "text/csv", "Module.ConvertToCSV", "Module.ParseCSV"
+      WebHelpers.RegisterConverter "csv", "text/csv", "Module.ConvertToCSV", "Module.ParseCSV"
 
       Dim Request As New WebRequest
       Request.CustomRequestFormat = "csv"
@@ -142,7 +142,7 @@ Properties:
 
       (Automatically sets `ResponseFormat` to `WebFormat.Custom`)
     example: |
-      RestHelpers.RegisterConverter "csv", "text/csv", "Module.ConvertToCSV", "Module.ParseCSV"
+      WebHelpers.RegisterConverter "csv", "text/csv", "Module.ConvertToCSV", "Module.ParseCSV"
 
       Dim Request As New WebRequest
       Request.CustomResponseFormat = "csv"

--- a/src/WebClient.cls
+++ b/src/WebClient.cls
@@ -458,7 +458,7 @@ End Function
 '
 ' @example
 ' ```VB.net
-' Dim Client As New RestClient
+' Dim Client As New WebClient
 '
 ' ' Just Server
 ' Client.SetProxy "proxy_server:80"


### PR DESCRIPTION
Great library! I noticed when getting started and working through the docs that I got tripped up by references to `RestHelpers` which I assume was renamed to `WebHelpers` at some point. I've updated the docs as such