### PR TITLE
Leave body as-is for ByteArray to support uploading binary files

### DIFF
--- a/src/WebRequest.cls
+++ b/src/WebRequest.cls
@@ -499,6 +499,8 @@ Public Property Get Body() As Variant
     If Not VBA.IsEmpty(web_pBody) Then
         If VBA.VarType(web_pBody) = vbString Then
             Body = web_pBody
+        ElseIf VBA.VarType(web_pBody) = vbArray Or vbByte Then
+            Body = web_pBody
         ElseIf IsEmpty(web_pConvertedBody) Then
             ' Convert body and cache
             Body = WebHelpers.ConvertToFormat(web_pBody, Me.RequestFormat, Me.CustomRequestFormat)


### PR DESCRIPTION
I was making my own Body using the ADODB.Recordset solution (see https://stackoverflow.com/questions/62165095/vba-send-file-in-binary-code-to-api-via-post-method), but this Property was being converted to rubbish. Excluding the ByteArray from getting converted makes it work without further alterations.