### PR TITLE
Fix cookie extraction for lowercase HTTP headers

### DIFF
--- a/src/WebResponse.cls
+++ b/src/WebResponse.cls
@@ -269,7 +269,7 @@ Public Function ExtractCookies(Headers As Collection) As Collection
     Dim web_Cookies As New Collection
 
     For Each web_Header In Headers
-        If web_Header("Key") = "Set-Cookie" Then
+        If LCase(web_Header("Key")) = "set-cookie" Then
             web_Cookie = web_Header("Value")
             If VBA.InStr(1, web_Cookie, "=") > 0 Then
                 web_Key = VBA.Mid$(web_Cookie, 1, VBA.InStr(1, web_Cookie, "=") - 1)


### PR DESCRIPTION
This code fixes a bug when web servers return cookies using a lowercase HTTP Set-Cookie header (e.g. Yahoo! Finance). HTTP headers are case-insensitive, so the code needs to normalize the header key name when looking for the Set-Cookie header.